### PR TITLE
Remove accidental DKP dependency from patch-nsmbu.py

### DIFF
--- a/nsmbu/patch-nsmbu.py
+++ b/nsmbu/patch-nsmbu.py
@@ -1,8 +1,4 @@
-import sys, os, struct, subprocess, string
-
-devkitppc = os.environ.get("DEVKITPPC")
-path_cc = os.path.join(devkitppc, "bin", "powerpc-eabi-gcc")
-path_objcopy = os.path.join(devkitppc, "bin", "powerpc-eabi-objcopy")
+import sys, struct
 
 game_base = open(sys.argv[1], "rb").read()
 game_base = bytearray(game_base)


### PR DESCRIPTION
Just removed a few lines that attempt to get the path to devkitPPC, which isn't actually used by this script.

Fixes (or at least partly fixes?) #1.